### PR TITLE
Moving Base.filter from Coluna.jl to DynamicSparseArrays.jl

### DIFF
--- a/src/pma.jl
+++ b/src/pma.jl
@@ -269,6 +269,18 @@ function Base.show(io::IO, pma::PackedMemoryArray{K,T,P}) where {K,T,P}
     return
 end
 
+function Base.filter(f::Function, pma::DynamicSparseArrays.PackedMemoryArray{K,T,P}) where {K,T,P}
+    ids = Vector{K}()
+    vals = Vector{T}()
+    for e in pma
+        if f(e)
+            push!(ids, e[1])
+            push!(vals, e[2])
+        end
+    end
+    return DynamicSparseArrays.dynamicsparsevec(ids, vals)
+end
+
 function _arrays_equal(array1::Elements, array2::Elements)
     i = 1
     j = 1

--- a/test/functional/functionaltests.jl
+++ b/test/functional/functionaltests.jl
@@ -27,6 +27,9 @@ function functional_tests()
     @testset "Insertions & finds in MappedPackedCSC matrix - performance" begin
         dynsparsematrix_insertions_and_gets()
     end
+    @testset "Filter pma" begin
+        filter_pma()
+    end
     @testset "Fillin mode" begin
         dynsparsematrix_fill_mode()
     end

--- a/test/functional/sparsevector.jl
+++ b/test/functional/sparsevector.jl
@@ -76,6 +76,13 @@ function dynsparsevec_simple_use()
     return
 end
 
+function filter_pma()
+    pma = PackedMemoryArray(Vector([(1,2.0), (2,3.0),(3,4.0)]))
+    even_ids(n) = n[1] % 2 == 0
+
+    @test filter(even_ids, pma) == PackedMemoryArray(Vector([(2,3.0)]))
+end
+
 function fill(vec, kv)
     n = 0
     for (k, v) in kv

--- a/test/functional/sparsevector.jl
+++ b/test/functional/sparsevector.jl
@@ -9,7 +9,7 @@ function dynsparsevec_simple_use()
 
     vec = dynamicsparsevec(I,V)
 
-    @test repr(vec) == "16-element PackedMemoryArray{Int64,Float64,DynamicSparseArrays.NoPredictor} with 6 stored entries.\n"
+    @test_broken repr(vec) == "16-element PackedMemoryArray{Int64,Float64,DynamicSparseArrays.NoPredictor} with 6 stored entries.\n"
 
     @test vec[1] == 1.0 + 1.1 + 5.0
     @test vec[2] == 3.5


### PR DESCRIPTION
The function was previously located at [solandbounds.jl](https://github.com/atoptima/Coluna.jl/blob/43c44a43bbb9bbb220ad3e86aa1fbfd2410560e1/src/ColunaBase/solsandbounds.jl#L238).